### PR TITLE
Use latest version for cookiecutter

### DIFF
--- a/{{cookiecutter.buildfolder}}/requirements.txt
+++ b/{{cookiecutter.buildfolder}}/requirements.txt
@@ -1,4 +1,4 @@
-cookiecutter==8.1.3
+cookiecutter==2.1.1
 cognite-sdk[pandas]==6.3.2
 click==8.1.3
 python-dotenv==0.21.1


### PR DESCRIPTION
I got an error for this when setting things up. I see the latest version is 2.1.1. I'm not sure why it was set to 8.1.3 in the first place. Has this version worked for 
anyone?
